### PR TITLE
docs: 'Should I try this today?' matrix + 'Ollie' project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,44 @@ The name plays on **o11y**, the standard observability abbreviation.
 
 ## Status
 
-This repository is in the middle of a planned rewrite. The legacy POC code (Prometheus + eBPF agent at the repo root, OpenTelemetry sink/query pipeline under `opentelemetry/`, the `obs/` logging library) has been removed; it remains on `main` and is reachable via `git log main`.
+**v0.3 dev preview** — the capture pipeline works end-to-end on real clusters. Deploying the DaemonSet on Kind and pointing nginx traffic at it produces `http_server_request_duration{k8s_pod_name="nginx-...",k8s_namespace_name="...",k8s_deployment_name="..."}` lines on the agent's `:9090/metrics` endpoint, with K8s identity attached automatically by OBI. L4 flows even carry dual-sided attribution (`k8s_src_*` + `k8s_dst_*`) for free.
 
-Active development lives on the `rewrite` branch. The **v0.1 Foundation** milestone has landed (scaffolding, public API skeletons, OBI adapter shell, container image, minimal DaemonSet) — the agent deploys but does nothing observable yet. Real eBPF capture lands with v0.2; HPA-ready custom metrics with v0.5; production-ready v1.0 follows.
+What's not yet built: CRD-driven onboarding (v0.4), in-cluster `tsdb` HEAD + PromQL (v0.5), `custom.metrics.k8s.io` for HPA (v0.5), AI-agent CEL streaming (v0.5), HTTP/2 + gRPC + TLS (v0.6), Helm chart + operator runbook (v1.0). Today's coverage is L4 TCP + HTTP/1.1.
+
+**Should you try it now?** See the [self-selection matrix](https://gke-labs.github.io/in-cluster-observability/#should-i-try-this-today) on the docs site — three columns covering who benefits today, who should come back at v0.4–v0.5, and who should wait for v1.0.
 
 Milestones are tracked at [github.com/gke-labs/in-cluster-observability/milestones](https://github.com/gke-labs/in-cluster-observability/milestones).
+
+## Try it on Kind
+
+```sh
+docker build -t ollie:v0.3 -f images/ollie/Dockerfile .
+kind create cluster --name ollie-v03
+kind load docker-image --name ollie-v03 ollie:v0.3
+docker pull otel/ebpf-instrument:v0.9.0
+kind load docker-image --name ollie-v03 otel/ebpf-instrument:v0.9.0
+kubectl apply -k k8s/
+```
+
+Full walkthrough (including the nginx workload + scrape recipe) is in the [Getting started](https://gke-labs.github.io/in-cluster-observability/docs/getting-started/) docs.
 
 ## Where to read what
 
 | You want to | Read |
 |---|---|
-| Understand what we're building | [`docs/requirements.md`](docs/requirements.md) |
-| Understand how we're building it | [`docs/design/architecture.md`](docs/design/architecture.md) |
+| Try it on a real cluster | [Getting started](https://gke-labs.github.io/in-cluster-observability/docs/getting-started/) |
+| See what's actually shipping | [What works today](https://gke-labs.github.io/in-cluster-observability/docs/what-works-today/) |
+| Understand the architecture | [Architecture](https://gke-labs.github.io/in-cluster-observability/docs/architecture/) or [`docs/design/architecture.md`](docs/design/architecture.md) |
+| Understand what we're building (full reqs) | [`docs/requirements.md`](docs/requirements.md) |
 | Read the decision log | [`docs/design/decisions.md`](docs/design/decisions.md) |
-| Set up your environment / contribute | [`AGENTS.md`](AGENTS.md), then [`docs/contributing.md`](docs/contributing.md) |
-| Browse the roadmap | [`docs/design/roadmap.md`](docs/design/roadmap.md) |
+| Contribute | [`AGENTS.md`](AGENTS.md) |
+| Browse the roadmap | [`docs/design/roadmap.md`](docs/design/roadmap.md) or the [docs-site roadmap](https://gke-labs.github.io/in-cluster-observability/docs/roadmap/) |
 
 A polished user-facing README ships with v1.0 ([issue #113](https://github.com/gke-labs/in-cluster-observability/issues/113)). This version is the in-flight pointer.
 
-## Module path
+## Naming
 
-The Go module path remains `github.com/gke-labs/in-cluster-observability` — the repository name. Within the project, binary, image, namespace, and metric prefix are all `ollie`.
+The project is **Ollie** — capitalized in prose, lowercase as the binary / image / metric prefix (`ollie`, `ollie:v0.3`, `ollie_capture_events_total`). The repository name is the more descriptive `gke-labs/in-cluster-observability`; the Go module path matches the repository (`github.com/gke-labs/in-cluster-observability`). The name plays on **o11y**, the standard observability abbreviation.
 
 ## License
 

--- a/docs/site/content/_index.md
+++ b/docs/site/content/_index.md
@@ -21,6 +21,38 @@ Transparent, eBPF-based network observability for Kubernetes workloads. Zero ins
 
 {{% /blocks/lead %}}
 
+{{% blocks/section color="white" %}}
+
+## Should I try this today?
+
+`in-cluster-observability` is on a milestone cadence and v0.3 is the first release with anything user-observable end-to-end. Use this to self-select before you spend 10 minutes on the Kind walkthrough.
+
+### Yes — try v0.3 today if …
+
+- You're **evaluating the architecture / direction** and want a working demo on Kind to validate the thesis (zero-instrumentation L4 + L7 metrics with K8s identity, OBI as a sibling container, single Prometheus URL).
+- You want **OBI's metrics pre-wired with K8s labels** without figuring out the OBI capability set, K8s informer RBAC, and `OTEL_EBPF_CONFIG_PATH` env var yourself — the manifest captures hard-won setup knowledge.
+- You have **HTTP/1.1 workloads** to play with (nginx, simple HTTP services) and an existing Prometheus to scrape them.
+- You want to **file issues or contribute** against the v0.4 controller, v0.5 store, or v0.6 hardening milestones.
+
+### Come back for v0.4–v0.5 if …
+
+- You want to **scope monitoring per-workload** via declarative `TrafficMonitor` CRDs (label selectors, not "every process on port 80"). → v0.4.
+- You want **HPA scaling driven by captured network metrics** (the `custom.metrics.k8s.io` API). → v0.5.
+- You want **in-cluster PromQL** over captured data without piping it out to Cortex / Mimir. → v0.5.
+- You want **span / edge persistence** and a query path for spans (`iobsctl spans --filter '...'`). → v0.5.
+- You want **AI-agent streaming** with CEL-filtered subscriptions. → v0.5.
+
+### Come back for v0.6 / v1.0 if …
+
+- Your workloads use **HTTP/2, gRPC, or TLS** — v0.3 covers L4 + HTTP/1.1 only; the rest lands in v0.6.
+- You're worried about **cardinality blowups** from high-variability URL paths — path templating, sampling, and peer-IP collapse arrive in v0.6.
+- You want a **Helm chart, operator runbook, upgrade guide, or multi-arch images** — those are v1.0 deliverables.
+- You're **running this in production** — wait for v1.0; v0.3 has no upgrade path and no SLOs.
+
+If you fit any of the "wait for" rows, the [roadmap]({{< relref "docs/roadmap.md" >}}) tracks expected scope per milestone, and starring / watching the [upstream repo](https://github.com/gke-labs/in-cluster-observability) is the easiest way to know when to revisit.
+
+{{% /blocks/section %}}
+
 {{% blocks/section color="dark" type="row" %}}
 
 {{% blocks/feature icon="fa-solid fa-eye" title="Zero instrumentation" url="docs/architecture/" %}}

--- a/docs/site/content/_index.md
+++ b/docs/site/content/_index.md
@@ -1,11 +1,15 @@
 ---
-title: in-cluster-observability
+title: Ollie
 ---
 
-{{< blocks/cover title="in-cluster-observability" image_anchor="top" height="med" >}}
+{{< blocks/cover title="Ollie" image_anchor="top" height="med" >}}
 
 <p class="lead mt-5">
 Transparent, eBPF-based network observability for Kubernetes workloads. Zero instrumentation — your apps don't change. L4 TCP + L7 HTTP metrics and spans with full K8s identity attached automatically, scrapable by Prometheus on every node.
+</p>
+
+<p class="mt-2 small">
+(The name plays on <em>o11y</em>, the standard observability abbreviation. Repository: <a href="https://github.com/gke-labs/in-cluster-observability">gke-labs/in-cluster-observability</a>.)
 </p>
 
 <a class="btn btn-lg btn-primary me-3 mb-4" href="docs/getting-started/">Get started <i class="fa-solid fa-arrow-right ms-2"></i></a>
@@ -15,7 +19,7 @@ Transparent, eBPF-based network observability for Kubernetes workloads. Zero ins
 
 {{% blocks/lead color="primary" %}}
 
-`in-cluster-observability` is a "more flexible Pixie" — an eBPF-based agent that captures network traffic on every Kubernetes node and turns it into metrics, spans, and topology edges, attributed by K8s identity (pod, namespace, deployment, service). Built on top of [OpenTelemetry eBPF Instrumentation (OBI)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation), it adds a thin agent that exposes everything on a single Prometheus scrape endpoint — with declarative CRD-driven onboarding, pluggable sinks, and an in-cluster store on the roadmap.
+**Ollie** is a "more flexible Pixie" — an eBPF-based agent that captures network traffic on every Kubernetes node and turns it into metrics, spans, and topology edges, attributed by K8s identity (pod, namespace, deployment, service). Built on top of [OpenTelemetry eBPF Instrumentation (OBI)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation), it adds a thin agent that exposes everything on a single Prometheus scrape endpoint — with declarative CRD-driven onboarding, pluggable sinks, and an in-cluster store on the roadmap.
 
 **Status: v0.3 dev preview.** Capture pipeline works end-to-end on real clusters; CRD/controller, in-cluster store, custom-metrics API for HPA, and AI-agent streaming arrive in v0.4–v0.5. See [What works today]({{< relref "docs/what-works-today.md" >}}) for the honest current shape.
 
@@ -25,7 +29,7 @@ Transparent, eBPF-based network observability for Kubernetes workloads. Zero ins
 
 ## Should I try this today?
 
-`in-cluster-observability` is on a milestone cadence and v0.3 is the first release with anything user-observable end-to-end. Use this to self-select before you spend 10 minutes on the Kind walkthrough.
+Ollie is on a milestone cadence and v0.3 is the first release with anything user-observable end-to-end. Use this to self-select before you spend 10 minutes on the Kind walkthrough.
 
 ### Yes — try v0.3 today if …
 

--- a/docs/site/content/docs/_index.md
+++ b/docs/site/content/docs/_index.md
@@ -7,7 +7,7 @@ menu:
     weight: 10
 ---
 
-You're in the `in-cluster-observability` reference docs. The site root has the project pitch; this section is the user-facing reference for the v0.3 dev preview.
+You're in the Ollie reference docs. The site root has the project pitch; this section is the user-facing reference for the v0.3 dev preview.
 
 ## Start here
 

--- a/docs/site/content/docs/architecture.md
+++ b/docs/site/content/docs/architecture.md
@@ -5,7 +5,7 @@ weight: 30
 description: "How the agent and OBI fit together — the sibling-container model and why the agent is intentionally thin."
 ---
 
-`in-cluster-observability` is built on top of [OpenTelemetry eBPF Instrumentation (OBI)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation). OBI does the eBPF capture and K8s metadata enrichment; this project adds the production deployment scaffolding plus an OTLP receiver carve-out that future milestones use as the hook point for CRD-driven onboarding (v0.4) and the in-cluster store (v0.5).
+Ollie is built on top of [OpenTelemetry eBPF Instrumentation (OBI)](https://github.com/open-telemetry/opentelemetry-ebpf-instrumentation). OBI does the eBPF capture and K8s metadata enrichment; Ollie adds the production deployment scaffolding plus an OTLP receiver carve-out that future milestones use as the hook point for CRD-driven onboarding (v0.4) and the in-cluster store (v0.5).
 
 This page describes the data path that's actually shipping in v0.3. For the full design log and the reasoning behind each choice, see the [ADRs in the repo](https://github.com/gke-labs/in-cluster-observability/blob/main/docs/design/decisions.md) — especially [ADR-0018](https://github.com/gke-labs/in-cluster-observability/blob/main/docs/design/decisions.md#adr-0018-obi-as-sibling-container-not-embedded-library) (sibling-container model) and [ADR-0021](https://github.com/gke-labs/in-cluster-observability/blob/main/docs/design/decisions.md#adr-0021-lean-v03--agent-re-uses-obis-native-enrichment) (lean v0.3 pivot to OBI native enrichment).
 

--- a/docs/site/content/docs/contributing.md
+++ b/docs/site/content/docs/contributing.md
@@ -2,7 +2,7 @@
 title: "Contributing"
 linkTitle: "Contributing"
 weight: 50
-description: "How to file issues, structure PRs, and work on in-cluster-observability."
+description: "How to file issues, structure PRs, and work on Ollie."
 ---
 
 The canonical contributor reference is [`AGENTS.md`](https://github.com/gke-labs/in-cluster-observability/blob/main/AGENTS.md) in the repo root — it covers conventions, build commands, layout, and the OBI integration boundary. This page is a short pointer.

--- a/docs/site/content/docs/getting-started.md
+++ b/docs/site/content/docs/getting-started.md
@@ -2,7 +2,7 @@
 title: "Getting started"
 linkTitle: "Getting started"
 weight: 10
-description: "Deploy in-cluster-observability on a Kind cluster, attach to a real workload, and see per-pod L4 + L7 metrics with K8s identity in under 10 minutes."
+description: "Deploy Ollie on a Kind cluster, attach to a real workload, and see per-pod L4 + L7 metrics with K8s identity in under 10 minutes."
 ---
 
 This walks from a fresh clone to per-pod HTTP metrics on a real nginx Deployment, scraped from the agent's `:9090` endpoint with `k8s.pod.name` / `k8s.namespace.name` / `k8s.deployment.name` labels attached by OBI.

--- a/docs/site/content/docs/what-works-today.md
+++ b/docs/site/content/docs/what-works-today.md
@@ -5,7 +5,7 @@ weight: 20
 description: "Honest v0.3 feature snapshot — what's captured, what the metric names look like, and what's not built yet."
 ---
 
-`in-cluster-observability` is at **v0.3 dev preview**. The capture path works end-to-end on real clusters, but several pieces from the original requirements (CRD-driven onboarding, in-cluster store + PromQL, HPA custom-metrics API, AI-agent streaming, TLS uprobes, peer.k8s.* on the L7 path) are still ahead. This page is the inventory.
+Ollie is at **v0.3 dev preview**. The capture path works end-to-end on real clusters, but several pieces from the original requirements (CRD-driven onboarding, in-cluster store + PromQL, HPA custom-metrics API, AI-agent streaming, TLS uprobes, peer.k8s.* on the L7 path) are still ahead. This page is the inventory.
 
 ## What's captured
 

--- a/docs/site/doc.go
+++ b/docs/site/doc.go
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package site is the Hugo + Docsy documentation site for
-// in-cluster-observability. The actual content lives under
-// content/; this file exists only so that `go test ./...` (run
-// by `ap test`) finds at least one Go package in the module —
-// otherwise it errors with "matched no packages" because the
-// only go.mod here is the Hugo module wrapper.
+// Package site is the Hugo + Docsy documentation site for Ollie.
+// The actual content lives under content/; this file exists only so
+// that `go test ./...` (run by `ap test`) finds at least one Go
+// package in the module — otherwise it errors with "matched no
+// packages" because the only go.mod here is the Hugo module wrapper.
 package site

--- a/docs/site/hugo.yaml
+++ b/docs/site/hugo.yaml
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Hugo configuration for the in-cluster-observability documentation
-# site.
+# Hugo configuration for the Ollie documentation site.
+# (Ollie is the project name; the repository lives at
+# gke-labs/in-cluster-observability — that path is unchanged.)
 #
 # Theme is Docsy (github.com/google/docsy) pulled in as a Hugo module
 # via go.mod. Docsy itself pulls Bootstrap + FontAwesome as Hugo
@@ -29,7 +30,7 @@
 # via .github/workflows/docs.yml.
 
 baseURL: "https://gke-labs.github.io/in-cluster-observability/"
-title: "in-cluster-observability"
+title: "Ollie"
 languageCode: "en-us"
 
 enableRobotsTXT: true
@@ -73,7 +74,7 @@ menu:
 
 params:
   copyright:
-    authors: "in-cluster-observability contributors"
+    authors: "Ollie contributors"
     from_year: 2026
 
   description: "Transparent eBPF-based network observability for Kubernetes workloads — zero-instrumentation L4/L7 metrics + spans with K8s identity, pluggable sinks, in-cluster query + HPA path."

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "in-cluster-observability-docs",
+  "name": "ollie-docs",
   "version": "0.0.1",
-  "description": "Build-time deps for the in-cluster-observability Hugo + Docsy docs site. Docsy's CSS pipeline shells out to PostCSS + autoprefixer.",
+  "description": "Build-time deps for the Ollie Hugo + Docsy docs site. Docsy's CSS pipeline shells out to PostCSS + autoprefixer.",
   "license": "Apache-2.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

Two docs-only follow-ups that landed on the `v0.3` branch *after* PR #127 was merged — bringing the live site at https://gke-labs.github.io/in-cluster-observability/ in line with what was actually intended for v0.3.

### 1. 'Should I try this today?' self-selection matrix on the landing page

Three columns so visitors can decide in 30 seconds whether to invest 10 minutes on the Kind walkthrough:

- **Try v0.3 today** — evaluators, contributors, HTTP/1.1 + own Prometheus, anyone who'd struggle with raw OBI setup.
- **Wait for v0.4–v0.5** — CRD-based scoping, HPA, in-cluster PromQL, span persistence, AI-agent streaming.
- **Wait for v0.6 / v1.0** — HTTP/2 / gRPC / TLS workloads, cardinality controls, Helm chart, production posture.

### 2. Use 'Ollie' as the project name across docs site + README

The README already used 'Ollie' (capitalized, matches the binary / image / metric prefix `ollie`). The Hugo docs site was still showing `in-cluster-observability` everywhere — that's the repository name, not the project name. Aligns the convention:

- Project name in prose / titles / branding: **Ollie**.
- Binary / image / metric prefix: `ollie` (lowercase; unchanged).
- Repository / Go module path: `gke-labs/in-cluster-observability` (unchanged).

Touches: `hugo.yaml` site title + copyright authors, `package.json` npm name, `doc.go` package comment, all five content pages.

Also refreshes the README's `## Status` section, which was stale since v0.1 (talked about the `rewrite` branch and v0.1 having just landed). Now reflects v0.3: capture works end-to-end, gap list with milestone links, points at the live docs site for the walkthrough + the new matrix. Adds a `## Naming` section codifying the Ollie / ollie / repo-name split so future contributors don't have to guess.

## Test plan

- [x] `cd docs/site && hugo --minify` clean (16 pages, 30 static files, no warnings).
- [x] Built page titles render `Ollie` / `<Page> | Ollie` (verified locally).
- [x] No code/manifest/test changes — docs-only follow-up.