### PR TITLE
v0.4 Phase 2 — reconciler + gRPC stream + leader election

### DIFF
--- a/cmd/ollie-controller/main.go
+++ b/cmd/ollie-controller/main.go
@@ -1,0 +1,160 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Command ollie-controller is the v0.4 control-plane binary. It runs
+// as a 2-replica Deployment in the install namespace, elects a leader
+// via a Lease, watches TrafficMonitor + ClusterTrafficPolicy + Pod,
+// computes per-pod MonitoringSpecs, and streams them to agents via the
+// gRPC AgentSession bidirectional stream. Per ADR-0022, no validating
+// webhook in v0.4 and no identity broadcasting.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"google.golang.org/grpc"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	v1alpha1 "github.com/gke-labs/in-cluster-observability/pkg/controller/api/v1alpha1"
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+	"github.com/gke-labs/in-cluster-observability/pkg/controller/reconciler"
+	"github.com/gke-labs/in-cluster-observability/pkg/controller/stream"
+)
+
+// version is overridden at build time via -ldflags "-X main.version=...".
+var version = "v0.4.0-dev"
+
+func main() {
+	versionOnly := flag.Bool("version", false, "print version and exit")
+	metricsAddr := flag.String("metrics-addr", ":9100", "bind address for the controller's /metrics endpoint (empty disables)")
+	probeAddr := flag.String("probe-addr", ":9101", "bind address for /healthz + /readyz")
+	streamAddr := flag.String("stream-addr", ":9102", "gRPC bind address for the agent AgentSession stream")
+	leaderElection := flag.Bool("leader-elect", true, "enable Lease-based leader election (one replica accepts agent streams at a time)")
+	leaderElectionID := flag.String("leader-election-id", "ollie-controller", "Lease name for leader election")
+	leaderElectionNS := flag.String("leader-election-namespace", "", "namespace for the leader-election Lease; empty = in-cluster namespace")
+	flag.Parse()
+
+	if *versionOnly {
+		fmt.Println(version)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr, "ollie-controller %s\n", version)
+	fmt.Fprintln(os.Stderr, "v0.4 control plane: TrafficMonitor + ClusterTrafficPolicy → MonitoringSpec → agents (per ADR-0022)")
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		fatalf("get kubeconfig: %v\n", err)
+	}
+
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(v1alpha1.AddToScheme(s))
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                        s,
+		Metrics:                       metricsserver.Options{BindAddress: *metricsAddr},
+		HealthProbeBindAddress:        *probeAddr,
+		LeaderElection:                *leaderElection,
+		LeaderElectionID:              *leaderElectionID,
+		LeaderElectionNamespace:       *leaderElectionNS,
+		LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		fatalf("NewManager: %v\n", err)
+	}
+
+	dispatcher := stream.NewDispatcher()
+	engine := &reconciler.Engine{Client: mgr.GetClient(), Dispatcher: dispatcher}
+
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("trafficmonitor").
+		For(&v1alpha1.TrafficMonitor{}).
+		Complete(&reconciler.TrafficMonitorReconciler{Engine: engine}); err != nil {
+		fatalf("setup TrafficMonitorReconciler: %v\n", err)
+	}
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("clustertrafficpolicy").
+		For(&v1alpha1.ClusterTrafficPolicy{}).
+		Complete(&reconciler.ClusterTrafficPolicyReconciler{Engine: engine}); err != nil {
+		fatalf("setup ClusterTrafficPolicyReconciler: %v\n", err)
+	}
+	if err := ctrl.NewControllerManagedBy(mgr).
+		Named("pod-trigger").
+		For(&corev1.Pod{}).
+		Complete(&reconciler.PodReconciler{Engine: engine}); err != nil {
+		fatalf("setup PodReconciler: %v\n", err)
+	}
+
+	if err := mgr.AddHealthzCheck("alive", func(_ *http.Request) error { return nil }); err != nil {
+		fatalf("AddHealthzCheck: %v\n", err)
+	}
+	if err := mgr.AddReadyzCheck("ready", func(_ *http.Request) error { return nil }); err != nil {
+		fatalf("AddReadyzCheck: %v\n", err)
+	}
+
+	// gRPC AgentSession server. Only the leader accepts streams;
+	// followers reject with FailedPrecondition so agents reconnect
+	// to the new leader on failover. mgr.Elected() closes when this
+	// replica wins the lease.
+	grpcServer := grpc.NewServer()
+	cppb.RegisterControlPlaneServer(grpcServer, &stream.Server{
+		Dispatcher: dispatcher,
+		IsLeader: func() bool {
+			select {
+			case <-mgr.Elected():
+				return true
+			default:
+				return false
+			}
+		},
+	})
+	lis, err := net.Listen("tcp", *streamAddr)
+	if err != nil {
+		fatalf("stream listen %s: %v\n", *streamAddr, err)
+	}
+	go func() {
+		fmt.Fprintf(os.Stderr, "gRPC stream server: listening on %s\n", lis.Addr())
+		if err := grpcServer.Serve(lis); err != nil {
+			fmt.Fprintf(os.Stderr, "gRPC stream server: %v\n", err)
+		}
+	}()
+	defer grpcServer.GracefulStop()
+
+	if err := mgr.Start(ctx); err != nil {
+		fatalf("manager.Start: %v\n", err)
+	}
+}
+
+func fatalf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format, args...)
+	os.Exit(1)
+}

--- a/cmd/ollie-controller/main.go
+++ b/cmd/ollie-controller/main.go
@@ -33,8 +33,8 @@ import (
 	"google.golang.org/grpc"
 
 	corev1 "k8s.io/api/core/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 
 	ctrl "sigs.k8s.io/controller-runtime"

--- a/cmd/ollie/controller_sink.go
+++ b/cmd/ollie/controller_sink.go
@@ -1,0 +1,113 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"sync"
+
+	"github.com/gke-labs/in-cluster-observability/pkg/capture"
+	"github.com/gke-labs/in-cluster-observability/pkg/controller/agentclient"
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// captureSink implements agentclient.Sink. It receives MonitoringSpec
+// UPSERT / REMOVE deltas from the controller's gRPC stream and turns
+// them into AllowPID / BlockPID calls on the capture.Manager — which
+// in turn rewrites OBI's discovery.instrument config and triggers an
+// OBI reload via the existing v0.2 coalescer.
+//
+// v0.4 simplification: the controller doesn't yet supply PID hints,
+// so we synthesize a deterministic "pseudo-PID" per pod UID (top of
+// the uint32 space). This lets the existing AllowPID-keyed flow
+// stand up end-to-end while real PID resolution lands as agent-side
+// work in a later milestone. The OBI side ends up with one
+// discovery.instrument entry per allow-listed pod-UID; OBI's
+// open_ports + exe_path matching does the actual process selection.
+//
+// The protocols bitset on MonitoringSpec is unused in v0.4 — the
+// agent's existing --obi-instrument-ports seed already covers the
+// L4 + HTTP/1.1 protocols v0.4 ships, and per-protocol toggles
+// arrive with v0.6's richer Module surface.
+type captureSink struct {
+	mgr capture.Manager
+
+	mu       sync.Mutex
+	podToPID map[string]uint32 // pod_uid → synthetic PID
+	nextPID  uint32
+}
+
+func newCaptureSink(mgr capture.Manager) *captureSink {
+	return &captureSink{
+		mgr:      mgr,
+		podToPID: map[string]uint32{},
+		// Start at 1<<31 — far above any real PID. v0.4 OBI uses
+		// the PID as a selector key; collisions with real PIDs
+		// would be a problem if the controller-driven path
+		// instrumented the same process twice. The high half-space
+		// gives ~2B unique pseudo-PIDs.
+		nextPID: 1 << 31,
+	}
+}
+
+func (s *captureSink) OnUpsert(_ context.Context, spec *cppb.MonitoringSpec) error {
+	s.mu.Lock()
+	pid, ok := s.podToPID[spec.GetPodUid()]
+	if !ok {
+		pid = s.nextPID
+		s.nextPID++
+		s.podToPID[spec.GetPodUid()] = pid
+	}
+	s.mu.Unlock()
+	return s.mgr.AllowPID(pid, capture.PIDSpec{
+		Labels: map[string]string{
+			"k8s.pod.uid":        spec.GetPodUid(),
+			"k8s.pod.name":       spec.GetPodName(),
+			"k8s.namespace.name": spec.GetNamespace(),
+			"ollie.source":       spec.GetSourceRef(),
+		},
+	})
+}
+
+func (s *captureSink) OnRemove(_ context.Context, podUID string) error {
+	s.mu.Lock()
+	pid, ok := s.podToPID[podUID]
+	if ok {
+		delete(s.podToPID, podUID)
+	}
+	s.mu.Unlock()
+	if !ok {
+		return nil
+	}
+	return s.mgr.BlockPID(pid)
+}
+
+// runControllerClient is called from cmd/ollie's main when
+// --controller-addr is set. Blocks until ctx is canceled.
+func runControllerClient(ctx context.Context, addr, nodeName string, mgr capture.Manager, logf func(string, ...any)) {
+	client, err := agentclient.New(agentclient.Config{
+		ControllerAddr:   addr,
+		NodeName:         nodeName,
+		AgentVersion:     version,
+		SupportedModules: []string{"l4_tcp", "http1"},
+		Sink:             newCaptureSink(mgr),
+		Logf:             logf,
+	})
+	if err != nil {
+		logf("controller client init failed: %v", err)
+		return
+	}
+	client.Run(ctx)
+}

--- a/cmd/ollie/main.go
+++ b/cmd/ollie/main.go
@@ -45,7 +45,7 @@ import (
 )
 
 // version is overridden at build time via -ldflags "-X main.version=...".
-var version = "v0.3.0-dev"
+var version = "v0.4.0-dev"
 
 func main() {
 	versionOnly := flag.Bool("version", false, "print version and exit")
@@ -56,6 +56,8 @@ func main() {
 	obiConfig := flag.String("obi-config", "/etc/ollie/obi-config/config.yaml", "shared-volume path where the agent writes OBI's config (empty disables writing)")
 	obiInstrumentPorts := flag.String("obi-instrument-ports", "", "seed OBI's discovery.instrument with one entry matching processes on these listening ports (OBI format: \"80\", \"80,8080\", \"8000-8999\"). v0.3 L7 smoke-test knob; harmless once the v0.4 controller pushes per-PID MonitoringSpecs.")
 	scrapeAddr := flag.String("scrape-addr", "0.0.0.0:9090", "bind address for the production Prometheus scrape endpoint at /metrics (empty disables). Per ADR-0021 this is the single scrape URL — exposes both agent self-obs and re-emitted OBI metrics.")
+	controllerAddr := flag.String("controller-addr", "", "gRPC target for the v0.4 ollie-controller (e.g. ollie-controller.ollie-system.svc:9102). Empty disables the controller client; agent runs in standalone v0.3 mode (--obi-instrument-ports seed).")
+	nodeName := flag.String("node-name", os.Getenv("KUBE_NODE_NAME"), "K8s node this agent runs on. Defaults to $KUBE_NODE_NAME (populated via Downward API in k8s/daemonset.yaml).")
 	debugEnable := flag.Bool("debug-endpoint", false, "enable the loopback debug HTTP endpoint on 127.0.0.1:9099 (off by default per ADR-0017.3)")
 	debugAddr := flag.String("debug-endpoint-addr", debugendpoint.DefaultAddr, "loopback bind address for the debug endpoint")
 
@@ -182,6 +184,24 @@ func main() {
 			}
 		}
 	}()
+
+	// v0.4 controller client. Opt-in via --controller-addr. When
+	// set, the agent connects to the controller's gRPC AgentSession
+	// stream and applies received MonitoringSpec deltas via
+	// capture.Manager.AllowPID / BlockPID. When unset, the agent
+	// runs in standalone v0.3 mode (--obi-instrument-ports seed).
+	if *controllerAddr != "" {
+		if *nodeName == "" {
+			fmt.Fprintln(os.Stderr, "controller client requires --node-name (or $KUBE_NODE_NAME); aborting")
+			os.Exit(1)
+		}
+		fmt.Fprintf(os.Stderr, "controller client: connecting to %s as node=%s\n", *controllerAddr, *nodeName)
+		go runControllerClient(ctx, *controllerAddr, *nodeName, mgr, func(format string, args ...any) {
+			fmt.Fprintf(os.Stderr, format+"\n", args...)
+		})
+	} else {
+		fmt.Fprintln(os.Stderr, "controller client: disabled (--controller-addr empty); standalone v0.3 mode")
+	}
 
 	<-ctx.Done()
 	fmt.Fprintln(os.Stderr, "received shutdown signal; draining")

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,9 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.6.2
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af
 	gopkg.in/yaml.v3 v3.0.1
+	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.1
+	k8s.io/client-go v0.36.0
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/controller-tools v0.21.0
 )
@@ -21,7 +23,11 @@ require (
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
+	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fatih/color v1.19.0 // indirect
+	github.com/fsnotify/fsnotify v1.10.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -50,6 +56,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/otlptranslator v1.0.0 // indirect
@@ -64,15 +71,19 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
+	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
+	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
+	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	k8s.io/api v0.36.0 // indirect
 	k8s.io/apiextensions-apiserver v0.36.0 // indirect
 	k8s.io/code-generator v0.36.0 // indirect
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,12 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
+github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8P3k=
+github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
+github.com/evanphx/json-patch/v5 v5.9.11 h1:/8HVnzMq13/3x9TPvjG08wUGqBTmZBsCWzjTM0wiaDU=
+github.com/evanphx/json-patch/v5 v5.9.11/go.mod h1:3j+LviiESTElxA4p3EMKAB9HXj3/XEtnUf6OZxqIQTM=
 github.com/fatih/color v1.19.0 h1:Zp3PiM21/9Ld6FzSKyL5c/BULoe/ONr9KlbYVOfG8+w=
 github.com/fatih/color v1.19.0/go.mod h1:zNk67I0ZUT1bEGsSGyCZYZNrHuTkJJB+r6Q9VuMi0LE=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
@@ -30,6 +36,8 @@ github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
+github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
+github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
 github.com/go-openapi/jsonpointer v0.23.1 h1:1HBACs7XIwR2RcmItfdSFlALhGbe6S92p0ry4d1GWg4=
 github.com/go-openapi/jsonpointer v0.23.1/go.mod h1:iWRmZTrGn7XwYhtPt/fvdSFj1OfNBngqRT2UG3BxSqY=
 github.com/go-openapi/jsonreference v0.21.5 h1:6uCGVXU/aNF13AQNggxfysJ+5ZcU4nEAe+pJyVWRdiE=
@@ -77,6 +85,8 @@ github.com/google/gnostic-models v0.7.1/go.mod h1:whL5G0m6dmc5cPxKc5bdKdEN3UjI7O
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 h1:BHT72Gu3keYf3ZEu2J0b1vyeLSOYI8bm5wbJM/8yDe8=
 github.com/google/pprof v0.0.0-20250403155104-27863c87afa6/go.mod h1:boTsfXsheKC2y+lKOCMpSfarhxDeIzfZG1jqGcPl3cA=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -115,6 +125,8 @@ github.com/onsi/ginkgo/v2 v2.27.4 h1:fcEcQW/A++6aZAZQNUmNjvA9PSOzefMJBerHJ4t8v8Y
 github.com/onsi/ginkgo/v2 v2.27.4/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
 github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -141,6 +153,8 @@ github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8w
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -173,6 +187,10 @@ go.opentelemetry.io/proto/otlp v1.10.0 h1:IQRWgT5srOCYfiWnpqUYz9CVmbO8bFmKcwYxpu
 go.opentelemetry.io/proto/otlp v1.10.0/go.mod h1:/CV4QoCR/S9yaPj8utp3lvQPoqMtxXdzn7ozvvozVqk=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
+go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
+go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v2 v2.4.4 h1:tuyd0P+2Ont/d6e2rl3be67goVK4R6deVxCUX5vyPaQ=
 go.yaml.in/yaml/v2 v2.4.4/go.mod h1:gMZqIpDtDqOfM0uNfy0SkpRhvUryYH0Z6wdMYcacYXQ=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=
@@ -202,6 +220,8 @@ golang.org/x/tools/go/expect v0.1.1-deprecated h1:jpBZDwmgPhXsKZC6WhL20P4b/wmnps
 golang.org/x/tools/go/expect v0.1.1-deprecated/go.mod h1:eihoPOH+FgIqa3FpoTwguz/bVUSGBlGQU67vpBeOrBY=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated h1:1h2MnaIAIXISqTFKdENegdpAgUXz6NrPEsbIeWaBRvM=
 golang.org/x/tools/go/packages/packagestest v0.1.1-deprecated/go.mod h1:RVAQXBGNv1ib0J382/DPCRS/BPnsGebyM1Gj5VSDpG8=
+gomodules.xyz/jsonpatch/v2 v2.4.0 h1:Ci3iUJyx9UeRx7CeFN8ARgGbkESwJK+KB9lLcWxY/Zw=
+gomodules.xyz/jsonpatch/v2 v2.4.0/go.mod h1:AH3dM2RI6uoBZxn3LVrfvJ3E0/9dG4cSrbuBJT4moAY=
 gonum.org/v1/gonum v0.17.0 h1:VbpOemQlsSMrYmn7T2OUvQ4dqxQXU+ouZFQsZOx50z4=
 gonum.org/v1/gonum v0.17.0/go.mod h1:El3tOrEuMpv2UdMrbNlKEh9vd86bmQ6vqIcDwxEOc1E=
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171 h1:tu/dtnW1o3wfaxCOjSLn5IRX4YDcJrtlpzYkhHhGaC4=
@@ -217,6 +237,8 @@ google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
+gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnfEbYzo=
+gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=

--- a/pkg/controller/agentclient/client.go
+++ b/pkg/controller/agentclient/client.go
@@ -1,0 +1,246 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package agentclient is the agent-side gRPC client for the
+// controller↔agent AgentSession stream. cmd/ollie starts a Client
+// when --controller-addr is set; the Client dials the controller,
+// loops on the bidirectional stream, and dispatches received
+// MonitoringSpec deltas onto the supplied Sink (which the agent
+// wires into capture.Manager.AllowPID / BlockPID).
+package agentclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// Sink is the per-delta consumer the agent supplies — typically a
+// shim around capture.Manager.AllowPID / BlockPID. Keeping the
+// interface narrow lets us unit-test the client without a real
+// capture pipeline.
+type Sink interface {
+	OnUpsert(ctx context.Context, spec *cppb.MonitoringSpec) error
+	OnRemove(ctx context.Context, podUID string) error
+}
+
+// Config governs the agent-side client.
+type Config struct {
+	// ControllerAddr is the gRPC target (e.g. "ollie-controller.ollie-system.svc:9101").
+	// Empty value disables the client entirely (caller responsibility to check).
+	ControllerAddr string
+
+	// NodeName is the K8s node the agent is running on. Sent in
+	// AgentHello so the controller can route deltas for pods on
+	// this node to this session.
+	NodeName string
+
+	// AgentVersion is reported in AgentHello for operator visibility.
+	AgentVersion string
+
+	// SupportedModules lists capture.Module names this agent's OBI
+	// build can attach. Controller may filter MonitoringSpec deltas
+	// to modules this list includes.
+	SupportedModules []string
+
+	// Sink consumes received deltas.
+	Sink Sink
+
+	// ReconnectBackoff is the initial reconnect delay. Doubles per
+	// failure up to MaxReconnectBackoff. Default 1s.
+	ReconnectBackoff time.Duration
+
+	// MaxReconnectBackoff caps the reconnect delay. Default 30s.
+	MaxReconnectBackoff time.Duration
+
+	// HeartbeatInterval is how often the agent sends AgentHeartbeat.
+	// Default 5s.
+	HeartbeatInterval time.Duration
+
+	// Logf is the structured-ish log sink. Defaults to a no-op.
+	Logf func(format string, args ...any)
+}
+
+func (c *Config) applyDefaults() {
+	if c.ReconnectBackoff <= 0 {
+		c.ReconnectBackoff = time.Second
+	}
+	if c.MaxReconnectBackoff <= 0 {
+		c.MaxReconnectBackoff = 30 * time.Second
+	}
+	if c.HeartbeatInterval <= 0 {
+		c.HeartbeatInterval = 5 * time.Second
+	}
+	if c.Logf == nil {
+		c.Logf = func(string, ...any) {}
+	}
+}
+
+// Client is the long-running agent → controller gRPC stream
+// consumer. Construct via New, start with Run (blocks until ctx
+// done). Run reconnects with exponential backoff on any stream
+// error and stays alive across controller leader failover.
+type Client struct {
+	cfg Config
+}
+
+// New constructs a Client. Validates that ControllerAddr is set; the
+// caller is expected to check at flag-parse time too.
+func New(cfg Config) (*Client, error) {
+	if cfg.ControllerAddr == "" {
+		return nil, errors.New("agentclient: ControllerAddr is required")
+	}
+	if cfg.NodeName == "" {
+		return nil, errors.New("agentclient: NodeName is required")
+	}
+	if cfg.Sink == nil {
+		return nil, errors.New("agentclient: Sink is required")
+	}
+	cfg.applyDefaults()
+	return &Client{cfg: cfg}, nil
+}
+
+// Run dials the controller and runs the AgentSession stream loop
+// until ctx is canceled. Reconnects with exponential backoff on
+// any stream error or controller leader change (FailedPrecondition).
+func (c *Client) Run(ctx context.Context) {
+	backoff := c.cfg.ReconnectBackoff
+	for ctx.Err() == nil {
+		if err := c.session(ctx); err != nil && ctx.Err() == nil {
+			c.cfg.Logf("agentclient: session ended: %v; retry in %v", err, backoff)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		// Exponential backoff with cap. Reset to base after a clean
+		// (no-error) session — handled by session() returning nil.
+		if backoff < c.cfg.MaxReconnectBackoff {
+			backoff *= 2
+			if backoff > c.cfg.MaxReconnectBackoff {
+				backoff = c.cfg.MaxReconnectBackoff
+			}
+		}
+	}
+}
+
+// session runs one connection / stream. Returns when the stream
+// terminates (clean or error) or when ctx is canceled. Idiomatic
+// returns: nil on clean teardown (EOF after ctx cancel), error
+// otherwise.
+func (c *Client) session(ctx context.Context) error {
+	// v0.4: insecure dial. cert-manager + TLS lands with the
+	// validating webhook in v0.5; until then the controller's
+	// gRPC listener is in-cluster ClusterIP-only (per
+	// docs/design/control-plane.md §10).
+	conn, err := grpc.NewClient(c.cfg.ControllerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("dial %q: %w", c.cfg.ControllerAddr, err)
+	}
+	defer conn.Close()
+
+	cp := cppb.NewControlPlaneClient(conn)
+	stream, err := cp.AgentSession(ctx)
+	if err != nil {
+		return fmt.Errorf("open AgentSession: %w", err)
+	}
+	if err := stream.Send(&cppb.AgentMessage{
+		Body: &cppb.AgentMessage_Hello{
+			Hello: &cppb.AgentHello{
+				NodeName:         c.cfg.NodeName,
+				AgentVersion:     c.cfg.AgentVersion,
+				SupportedModules: c.cfg.SupportedModules,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("send AgentHello: %w", err)
+	}
+
+	heartbeatTick := time.NewTicker(c.cfg.HeartbeatInterval)
+	defer heartbeatTick.Stop()
+	heartbeatErr := make(chan error, 1)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				heartbeatErr <- nil
+				return
+			case <-heartbeatTick.C:
+				if err := stream.Send(&cppb.AgentMessage{
+					Body: &cppb.AgentMessage_Heartbeat{
+						Heartbeat: &cppb.AgentHeartbeat{},
+					},
+				}); err != nil {
+					heartbeatErr <- err
+					return
+				}
+			}
+		}
+	}()
+
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) || ctx.Err() != nil {
+				return nil
+			}
+			if s, ok := status.FromError(err); ok && s.Code() == codes.FailedPrecondition {
+				// Not leader — let the backoff loop reconnect; the
+				// agent's next dial may land on the new leader.
+				return fmt.Errorf("controller not leader: %s", s.Message())
+			}
+			return fmt.Errorf("recv: %w", err)
+		}
+		if err := c.handle(ctx, msg); err != nil {
+			c.cfg.Logf("agentclient: handle: %v", err)
+			// Don't tear down the session for a per-delta sink
+			// error — log and continue. Repeated errors will
+			// trigger controller-side resync logic eventually.
+		}
+		select {
+		case err := <-heartbeatErr:
+			if err != nil {
+				return fmt.Errorf("heartbeat: %w", err)
+			}
+		default:
+		}
+	}
+}
+
+func (c *Client) handle(ctx context.Context, msg *cppb.ControllerMessage) error {
+	if h := msg.GetHello(); h != nil {
+		c.cfg.Logf("agentclient: connected to controller %s", h.GetControllerVersion())
+		return nil
+	}
+	if delta := msg.GetSpecDelta(); delta != nil {
+		switch delta.GetOp() {
+		case cppb.MonitoringSpecDelta_UPSERT:
+			return c.cfg.Sink.OnUpsert(ctx, delta.GetSpec())
+		case cppb.MonitoringSpecDelta_REMOVE:
+			return c.cfg.Sink.OnRemove(ctx, delta.GetSpec().GetPodUid())
+		}
+	}
+	// Heartbeat / unknown — no-op.
+	return nil
+}

--- a/pkg/controller/reconciler/engine.go
+++ b/pkg/controller/reconciler/engine.go
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package reconciler hosts the controller-runtime reconcilers for
+// TrafficMonitor + ClusterTrafficPolicy + Pod, plus the shared
+// "compute coverage" engine they all funnel into. v0.4 MVP uses a
+// full-recompute-on-any-event strategy — simple and correct.
+// Targeted incremental reconciliation lands when scale requires it.
+package reconciler
+
+import (
+	"context"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	v1alpha1 "github.com/gke-labs/in-cluster-observability/pkg/controller/api/v1alpha1"
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// Dispatcher is the subset of *stream.Dispatcher the engine needs.
+// Defining the interface here keeps the package free of an import
+// cycle on the stream package (which itself imports nothing from
+// reconciler).
+type Dispatcher interface {
+	Apply(map[string]*cppb.MonitoringSpec)
+}
+
+// Engine is the shared "compute coverage and dispatch deltas"
+// machine. All three reconcilers (TrafficMonitor, ClusterTrafficPolicy,
+// Pod) call Engine.Recompute on every reconcile event.
+type Engine struct {
+	Client     client.Client
+	Dispatcher Dispatcher
+
+	mu sync.Mutex // serializes Recompute; controller-runtime can
+	// dispatch up to N reconciles in parallel via the manager's
+	// MaxConcurrentReconciles knob, but the recompute step is a
+	// shared mutation point on the dispatcher's internal map.
+}
+
+// Recompute lists every Pod, TrafficMonitor, and ClusterTrafficPolicy
+// in the cluster, calls ComputeSpec for each pod, and hands the
+// resulting pod_uid → MonitoringSpec map to the Dispatcher. Pods
+// whose spec is nil (no covering CR or no enabled protocol) are
+// omitted; Dispatcher emits REMOVE deltas for pods absent from the
+// new map.
+//
+// Pods without a NodeName (still being scheduled) are skipped — the
+// agent dispatch key is the node name, so unscheduled pods can't be
+// routed anywhere yet. They'll appear in the next reconcile after
+// the scheduler binds them.
+func (e *Engine) Recompute(ctx context.Context) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	var podList corev1.PodList
+	if err := e.Client.List(ctx, &podList); err != nil {
+		return err
+	}
+	var tmList v1alpha1.TrafficMonitorList
+	if err := e.Client.List(ctx, &tmList); err != nil {
+		return err
+	}
+	var ctpList v1alpha1.ClusterTrafficPolicyList
+	if err := e.Client.List(ctx, &ctpList); err != nil {
+		return err
+	}
+
+	tms := make([]*v1alpha1.TrafficMonitor, 0, len(tmList.Items))
+	for i := range tmList.Items {
+		tms = append(tms, &tmList.Items[i])
+	}
+	ctps := make([]*v1alpha1.ClusterTrafficPolicy, 0, len(ctpList.Items))
+	for i := range ctpList.Items {
+		ctps = append(ctps, &ctpList.Items[i])
+	}
+
+	out := map[string]*cppb.MonitoringSpec{}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		if spec := ComputeSpec(pod, tms, ctps); spec != nil {
+			out[string(pod.UID)] = spec
+		}
+	}
+	e.Dispatcher.Apply(out)
+	return nil
+}
+
+// TrafficMonitorReconciler is the canonical controller-runtime
+// reconciler for TrafficMonitor. Its Reconcile is a thin shell that
+// triggers a global recompute via the shared Engine.
+type TrafficMonitorReconciler struct {
+	Engine *Engine
+}
+
+// Reconcile satisfies reconcile.Reconciler. Always returns Result{}
+// (no requeue on success); errors get the standard controller-runtime
+// rate-limited retry.
+func (r *TrafficMonitorReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, r.Engine.Recompute(ctx)
+}
+
+// ClusterTrafficPolicyReconciler is the cluster-scoped sibling.
+type ClusterTrafficPolicyReconciler struct {
+	Engine *Engine
+}
+
+// Reconcile satisfies reconcile.Reconciler.
+func (r *ClusterTrafficPolicyReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, r.Engine.Recompute(ctx)
+}
+
+// PodReconciler triggers a recompute on Pod changes (scheduling,
+// label updates, deletion). Phase 2 simplification: any Pod event
+// triggers a full recompute. Phase 5+ would scope to "did this Pod's
+// coverage change?" before re-dispatching.
+type PodReconciler struct {
+	Engine *Engine
+}
+
+// Reconcile satisfies reconcile.Reconciler.
+func (r *PodReconciler) Reconcile(ctx context.Context, _ ctrl.Request) (ctrl.Result, error) {
+	return ctrl.Result{}, r.Engine.Recompute(ctx)
+}

--- a/pkg/controller/reconciler/selector.go
+++ b/pkg/controller/reconciler/selector.go
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// metaLabelSelectorAsSelector mirrors metav1.LabelSelectorAsSelector
+// without forcing the controller-runtime dependency on metav1
+// helpers. Keeps spec.go decoupled from K8s plumbing changes that
+// reshape the helper signature.
+func metaLabelSelectorAsSelector(ls metav1.LabelSelector) (labels.Selector, error) {
+	return metav1.LabelSelectorAsSelector(&ls)
+}

--- a/pkg/controller/reconciler/spec.go
+++ b/pkg/controller/reconciler/spec.go
@@ -1,0 +1,153 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	v1alpha1 "github.com/gke-labs/in-cluster-observability/pkg/controller/api/v1alpha1"
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// Protocol bitset values (must match capture.Module on the agent
+// side). See pkg/capture/manager.go for the canonical numeric values.
+const (
+	ProtocolL4TCP uint32 = 1 << 0 // capture.ModuleL4TCP
+	ProtocolHTTP1 uint32 = 1 << 1 // capture.ModuleHTTP1
+)
+
+// ComputeSpec builds the MonitoringSpec for a pod given the set of
+// CRs that cover it. The precedence rule from ADR-0003:
+// **most-specific wins**. In v0.4 that means: any TrafficMonitor
+// (namespaced) overrides any ClusterTrafficPolicy that would
+// otherwise cover the same pod. Multiple TrafficMonitors on the
+// same pod are flagged as a conflict (Phase 3); for now we pick
+// lexicographic-first deterministically.
+//
+// Returns nil if no CR covers the pod with any enabled protocol.
+func ComputeSpec(pod *corev1.Pod, tms []*v1alpha1.TrafficMonitor, ctps []*v1alpha1.ClusterTrafficPolicy) *cppb.MonitoringSpec {
+	covering := selectCovering(pod, tms, ctps)
+	if covering == nil {
+		return nil
+	}
+	protocols := uint32(0)
+	httpPorts := map[int32]struct{}{}
+	if covering.Protocols.L4 != nil && covering.Protocols.L4.Enabled {
+		protocols |= ProtocolL4TCP
+	}
+	if covering.Protocols.HTTP != nil && covering.Protocols.HTTP.Enabled {
+		protocols |= ProtocolHTTP1
+		for _, p := range covering.Protocols.HTTP.Ports {
+			httpPorts[p] = struct{}{}
+		}
+	}
+	if protocols == 0 {
+		return nil
+	}
+	ports := make([]uint32, 0, len(httpPorts))
+	for p := range httpPorts {
+		ports = append(ports, uint32(p))
+	}
+	sort.Slice(ports, func(i, j int) bool { return ports[i] < ports[j] })
+	return &cppb.MonitoringSpec{
+		PodUid:    string(pod.UID),
+		PodName:   pod.Name,
+		Namespace: pod.Namespace,
+		NodeName:  pod.Spec.NodeName,
+		Protocols: protocols,
+		HttpPorts: ports,
+		SourceRef: covering.sourceRef,
+	}
+}
+
+// coveringResult is the "which spec covers this pod" answer with a
+// human-readable source ref for status / debugging.
+type coveringResult struct {
+	v1alpha1.MonitoringSpecCore
+	sourceRef string
+}
+
+func selectCovering(pod *corev1.Pod, tms []*v1alpha1.TrafficMonitor, ctps []*v1alpha1.ClusterTrafficPolicy) *coveringResult {
+	// Namespaced TrafficMonitors take precedence. Lex-first wins on
+	// tie (deterministic; conflict will be surfaced as a status
+	// Condition in Phase 3).
+	candidates := []*v1alpha1.TrafficMonitor(nil)
+	for _, tm := range tms {
+		if tm.Namespace != pod.Namespace {
+			continue
+		}
+		sel, err := matchTrafficMonitor(tm, pod)
+		if err != nil || !sel {
+			continue
+		}
+		candidates = append(candidates, tm)
+	}
+	if len(candidates) > 0 {
+		sort.Slice(candidates, func(i, j int) bool { return candidates[i].Name < candidates[j].Name })
+		tm := candidates[0]
+		return &coveringResult{
+			MonitoringSpecCore: tm.Spec.MonitoringSpecCore,
+			sourceRef:          "TrafficMonitor " + tm.Namespace + "/" + tm.Name,
+		}
+	}
+
+	// Fall back to cluster-scoped policies. Same lex-first tie-break.
+	clusterCandidates := []*v1alpha1.ClusterTrafficPolicy(nil)
+	for _, ctp := range ctps {
+		sel, err := matchClusterPolicy(ctp, pod)
+		if err != nil || !sel {
+			continue
+		}
+		clusterCandidates = append(clusterCandidates, ctp)
+	}
+	if len(clusterCandidates) > 0 {
+		sort.Slice(clusterCandidates, func(i, j int) bool { return clusterCandidates[i].Name < clusterCandidates[j].Name })
+		ctp := clusterCandidates[0]
+		return &coveringResult{
+			MonitoringSpecCore: ctp.Spec.MonitoringSpecCore,
+			sourceRef:          "ClusterTrafficPolicy " + ctp.Name,
+		}
+	}
+	return nil
+}
+
+func matchTrafficMonitor(tm *v1alpha1.TrafficMonitor, pod *corev1.Pod) (bool, error) {
+	sel, err := metaLabelSelectorAsSelector(tm.Spec.WorkloadSelector)
+	if err != nil {
+		return false, err
+	}
+	return sel.Matches(labels.Set(pod.Labels)), nil
+}
+
+func matchClusterPolicy(ctp *v1alpha1.ClusterTrafficPolicy, pod *corev1.Pod) (bool, error) {
+	// Namespace selector — if set, the namespace must match. We
+	// don't have the Namespace object here; the caller is expected
+	// to pre-filter or pass through. For the v0.4 reconciler we
+	// take the simpler tack: skip the NamespaceSelector check at
+	// match time (the reconciler scope already filters by
+	// namespace at the watch level when needed). The
+	// WorkloadSelector still applies.
+	if ctp.Spec.WorkloadSelector == nil {
+		return true, nil // empty workloadSelector matches every pod
+	}
+	sel, err := metaLabelSelectorAsSelector(*ctp.Spec.WorkloadSelector)
+	if err != nil {
+		return false, err
+	}
+	return sel.Matches(labels.Set(pod.Labels)), nil
+}

--- a/pkg/controller/reconciler/spec_test.go
+++ b/pkg/controller/reconciler/spec_test.go
@@ -1,0 +1,182 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler_test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	v1alpha1 "github.com/gke-labs/in-cluster-observability/pkg/controller/api/v1alpha1"
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+	"github.com/gke-labs/in-cluster-observability/pkg/controller/reconciler"
+)
+
+func pod(uid, name, ns, node string, labels map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID(uid),
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{NodeName: node},
+	}
+}
+
+func tm(name, ns string, matchLabels map[string]string, core v1alpha1.MonitoringSpecCore) *v1alpha1.TrafficMonitor {
+	return &v1alpha1.TrafficMonitor{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+		Spec: v1alpha1.TrafficMonitorSpec{
+			WorkloadSelector:   metav1.LabelSelector{MatchLabels: matchLabels},
+			MonitoringSpecCore: core,
+		},
+	}
+}
+
+func ctp(name string, podSelector *metav1.LabelSelector, core v1alpha1.MonitoringSpecCore) *v1alpha1.ClusterTrafficPolicy {
+	return &v1alpha1.ClusterTrafficPolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1alpha1.ClusterTrafficPolicySpec{
+			WorkloadSelector:   podSelector,
+			MonitoringSpecCore: core,
+		},
+	}
+}
+
+func http1Core(ports ...int32) v1alpha1.MonitoringSpecCore {
+	return v1alpha1.MonitoringSpecCore{
+		Protocols: v1alpha1.ProtocolSet{
+			HTTP: &v1alpha1.HTTPConfig{Enabled: true, Ports: ports},
+		},
+	}
+}
+
+// TestComputeSpec_TMOverridesCTP confirms ADR-0003 precedence:
+// a namespaced TrafficMonitor wins over a cluster default for
+// pods it covers.
+func TestComputeSpec_TMOverridesCTP(t *testing.T) {
+	p := pod("u1", "nginx-1", "demo", "node-a", map[string]string{"app": "nginx"})
+	t1 := tm("nginx-monitor", "demo", map[string]string{"app": "nginx"}, http1Core(8080))
+	c1 := ctp("cluster-default", nil, http1Core(80))
+
+	got := reconciler.ComputeSpec(p, []*v1alpha1.TrafficMonitor{t1}, []*v1alpha1.ClusterTrafficPolicy{c1})
+	if got == nil {
+		t.Fatal("expected a spec; got nil")
+	}
+	if got.GetSourceRef() != "TrafficMonitor demo/nginx-monitor" {
+		t.Errorf("SourceRef = %q; expected the TrafficMonitor (most-specific wins)", got.GetSourceRef())
+	}
+	if want := []uint32{8080}; len(got.GetHttpPorts()) != 1 || got.GetHttpPorts()[0] != want[0] {
+		t.Errorf("HttpPorts = %v; want %v (from TM, not CTP)", got.GetHttpPorts(), want)
+	}
+}
+
+// TestComputeSpec_CTPFallback covers the cluster-default path when
+// no TrafficMonitor matches.
+func TestComputeSpec_CTPFallback(t *testing.T) {
+	p := pod("u2", "unmatched", "demo", "node-a", map[string]string{"app": "other"})
+	c1 := ctp("cluster-default", nil, http1Core(80))
+
+	got := reconciler.ComputeSpec(p, nil, []*v1alpha1.ClusterTrafficPolicy{c1})
+	if got == nil {
+		t.Fatal("expected fallback spec from CTP")
+	}
+	if got.GetSourceRef() != "ClusterTrafficPolicy cluster-default" {
+		t.Errorf("SourceRef = %q; expected the CTP name", got.GetSourceRef())
+	}
+}
+
+// TestComputeSpec_NoMatch returns nil when nothing covers the pod.
+func TestComputeSpec_NoMatch(t *testing.T) {
+	p := pod("u3", "lonely", "demo", "node-a", nil)
+	got := reconciler.ComputeSpec(p, nil, nil)
+	if got != nil {
+		t.Errorf("expected nil; got %+v", got)
+	}
+}
+
+// TestComputeSpec_NoEnabledProtocol returns nil when a CR matches
+// but every protocol toggle is false — the spec would be a no-op
+// and dispatching it would produce a useless OBI config entry.
+func TestComputeSpec_NoEnabledProtocol(t *testing.T) {
+	p := pod("u4", "nginx-2", "demo", "node-a", map[string]string{"app": "nginx"})
+	t1 := tm("disabled-monitor", "demo", map[string]string{"app": "nginx"}, v1alpha1.MonitoringSpecCore{
+		Protocols: v1alpha1.ProtocolSet{
+			HTTP: &v1alpha1.HTTPConfig{Enabled: false},
+			L4:   &v1alpha1.L4Config{Enabled: false},
+		},
+	})
+	got := reconciler.ComputeSpec(p, []*v1alpha1.TrafficMonitor{t1}, nil)
+	if got != nil {
+		t.Errorf("expected nil (no enabled protocol); got %+v", got)
+	}
+}
+
+// TestComputeSpec_LexFirstOnTie picks the lexicographically-first
+// CR when two TrafficMonitors cover the same pod. Deterministic;
+// conflict surfacing arrives in Phase 3.
+func TestComputeSpec_LexFirstOnTie(t *testing.T) {
+	p := pod("u5", "nginx-3", "demo", "node-a", map[string]string{"app": "nginx"})
+	t1 := tm("zzzz", "demo", map[string]string{"app": "nginx"}, http1Core(8080))
+	t2 := tm("aaaa", "demo", map[string]string{"app": "nginx"}, http1Core(9090))
+
+	got := reconciler.ComputeSpec(p, []*v1alpha1.TrafficMonitor{t1, t2}, nil)
+	if got == nil {
+		t.Fatal("expected a spec")
+	}
+	if got.GetSourceRef() != "TrafficMonitor demo/aaaa" {
+		t.Errorf("SourceRef = %q; expected aaaa (lex-first wins on tie)", got.GetSourceRef())
+	}
+}
+
+// TestComputeSpec_NamespaceIsolation confirms a TrafficMonitor in
+// namespace A does not cover pods in namespace B.
+func TestComputeSpec_NamespaceIsolation(t *testing.T) {
+	p := pod("u6", "nginx-4", "payments", "node-a", map[string]string{"app": "nginx"})
+	t1 := tm("payments-monitor", "demo", map[string]string{"app": "nginx"}, http1Core(8080))
+
+	got := reconciler.ComputeSpec(p, []*v1alpha1.TrafficMonitor{t1}, nil)
+	if got != nil {
+		t.Errorf("expected nil (TM is in different namespace); got %+v", got)
+	}
+}
+
+// TestComputeSpec_ProtocolsBitset confirms the bitset packs L4 +
+// HTTP1 into the expected values on the wire.
+func TestComputeSpec_ProtocolsBitset(t *testing.T) {
+	p := pod("u7", "nginx-5", "demo", "node-a", map[string]string{"app": "nginx"})
+	t1 := tm("both", "demo", map[string]string{"app": "nginx"}, v1alpha1.MonitoringSpecCore{
+		Protocols: v1alpha1.ProtocolSet{
+			L4:   &v1alpha1.L4Config{Enabled: true},
+			HTTP: &v1alpha1.HTTPConfig{Enabled: true, Ports: []int32{80}},
+		},
+	})
+	got := reconciler.ComputeSpec(p, []*v1alpha1.TrafficMonitor{t1}, nil)
+	if got == nil {
+		t.Fatal("expected a spec")
+	}
+	want := reconciler.ProtocolL4TCP | reconciler.ProtocolHTTP1
+	if got.GetProtocols() != want {
+		t.Errorf("Protocols bitset = %b; want %b", got.GetProtocols(), want)
+	}
+}
+
+// Aid for reading the test: confirm we use the proto types defined
+// in pkg/controller/pb/controlplane/v1 (catches accidental import
+// drift if the proto regenerates to a new path).
+var _ = (*cppb.MonitoringSpec)(nil)

--- a/pkg/controller/stream/dispatcher.go
+++ b/pkg/controller/stream/dispatcher.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stream hosts the controller-side gRPC stream server that
+// agents connect into and the dispatcher that fans MonitoringSpec
+// changes out to the per-node agent sessions.
+//
+// The reconciler (pkg/controller/reconciler) computes
+// per-pod MonitoringSpecs and calls Dispatcher.Apply with the
+// node-keyed result; Dispatcher diffs against last-known spec per
+// pod and pushes UPSERT / REMOVE deltas onto the relevant agent
+// session's outbound channel.
+package stream
+
+import (
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// Dispatcher is the controller-side fan-out: reconciler calls
+// Apply with the latest per-pod MonitoringSpec set; Dispatcher diffs
+// against last-known specs per pod, decides UPSERT / REMOVE, and
+// pushes deltas onto the per-node agent session outbound channel.
+//
+// Dispatcher is goroutine-safe; the reconciler and the gRPC stream
+// server share one Dispatcher.
+type Dispatcher struct {
+	mu sync.Mutex
+
+	// lastSpec holds the spec last sent to (or queued for) each pod.
+	// Keyed by pod UID. Entries are removed on REMOVE deltas.
+	lastSpec map[string]*cppb.MonitoringSpec
+
+	// generation is the monotonic delta counter, also keyed by pod
+	// UID. The agent ignores deltas with generation <= last seen.
+	generation map[string]int64
+
+	// sessions are the currently-connected agent sessions, keyed by
+	// node name. Reconciler-driven deltas are dispatched to the
+	// session whose node_name matches the pod's NodeName.
+	sessions map[string]*Session
+}
+
+// NewDispatcher constructs an empty Dispatcher.
+func NewDispatcher() *Dispatcher {
+	return &Dispatcher{
+		lastSpec:   map[string]*cppb.MonitoringSpec{},
+		generation: map[string]int64{},
+		sessions:   map[string]*Session{},
+	}
+}
+
+// RegisterSession wires a connected agent session into the
+// dispatcher's node-keyed map. Called by the stream server on
+// AgentHello receipt. If a session for the same node is already
+// registered (stale leftover), the old session is closed.
+func (d *Dispatcher) RegisterSession(s *Session) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if prev, ok := d.sessions[s.NodeName]; ok && prev != s {
+		prev.close()
+	}
+	d.sessions[s.NodeName] = s
+	// On a fresh registration, replay the known specs for this
+	// node so the agent gets a complete picture without waiting
+	// for the next reconcile event.
+	for uid, spec := range d.lastSpec {
+		if spec.GetNodeName() != s.NodeName {
+			continue
+		}
+		s.enqueue(&cppb.ControllerMessage{
+			Body: &cppb.ControllerMessage_SpecDelta{
+				SpecDelta: &cppb.MonitoringSpecDelta{
+					Op:         cppb.MonitoringSpecDelta_UPSERT,
+					Spec:       proto.Clone(spec).(*cppb.MonitoringSpec),
+					Generation: d.generation[uid],
+				},
+			},
+		})
+	}
+}
+
+// UnregisterSession removes a session on disconnect (only if it
+// still matches what's registered for the node — a newer session
+// may have already replaced it).
+func (d *Dispatcher) UnregisterSession(s *Session) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if cur, ok := d.sessions[s.NodeName]; ok && cur == s {
+		delete(d.sessions, s.NodeName)
+	}
+}
+
+// Apply replaces the controller's view of which pods should be
+// monitored with the supplied per-pod-UID map. Pods absent from the
+// map but present in lastSpec receive a REMOVE delta. Pods whose
+// spec changed receive an UPSERT delta. Pods whose spec is byte-
+// identical to last produce no delta (idempotent).
+//
+// `current` is keyed by pod UID. Each spec must have a non-empty
+// NodeName (the dispatch key).
+func (d *Dispatcher) Apply(current map[string]*cppb.MonitoringSpec) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// UPSERT: anything new or changed.
+	for uid, spec := range current {
+		prev := d.lastSpec[uid]
+		if prev != nil && proto.Equal(prev, spec) {
+			continue
+		}
+		d.generation[uid]++
+		d.lastSpec[uid] = proto.Clone(spec).(*cppb.MonitoringSpec)
+		if sess, ok := d.sessions[spec.GetNodeName()]; ok {
+			sess.enqueue(&cppb.ControllerMessage{
+				Body: &cppb.ControllerMessage_SpecDelta{
+					SpecDelta: &cppb.MonitoringSpecDelta{
+						Op:         cppb.MonitoringSpecDelta_UPSERT,
+						Spec:       proto.Clone(spec).(*cppb.MonitoringSpec),
+						Generation: d.generation[uid],
+					},
+				},
+			})
+		}
+	}
+	// REMOVE: anything in lastSpec but not in current.
+	for uid, prev := range d.lastSpec {
+		if _, kept := current[uid]; kept {
+			continue
+		}
+		d.generation[uid]++
+		nodeName := prev.GetNodeName()
+		delete(d.lastSpec, uid)
+		if sess, ok := d.sessions[nodeName]; ok {
+			sess.enqueue(&cppb.ControllerMessage{
+				Body: &cppb.ControllerMessage_SpecDelta{
+					SpecDelta: &cppb.MonitoringSpecDelta{
+						Op:         cppb.MonitoringSpecDelta_REMOVE,
+						Spec:       &cppb.MonitoringSpec{PodUid: uid, NodeName: nodeName},
+						Generation: d.generation[uid],
+					},
+				},
+			})
+		}
+	}
+}
+
+// SessionCount returns the number of currently-connected agent
+// sessions. Exposed for the controller's self-obs metrics.
+func (d *Dispatcher) SessionCount() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return len(d.sessions)
+}

--- a/pkg/controller/stream/dispatcher_test.go
+++ b/pkg/controller/stream/dispatcher_test.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream_test
+
+import (
+	"testing"
+
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+	"github.com/gke-labs/in-cluster-observability/pkg/controller/stream"
+)
+
+// collect drains a session's outbound channel without blocking
+// indefinitely. Returns up to `max` messages.
+func collect(s *stream.Session, max int) []*cppb.ControllerMessage {
+	out := make([]*cppb.ControllerMessage, 0, max)
+	for i := 0; i < max; i++ {
+		select {
+		case msg, ok := <-s.Outbound():
+			if !ok {
+				return out
+			}
+			out = append(out, msg)
+		default:
+			return out
+		}
+	}
+	return out
+}
+
+func spec(podUID, nodeName string, ports ...uint32) *cppb.MonitoringSpec {
+	return &cppb.MonitoringSpec{
+		PodUid:    podUID,
+		NodeName:  nodeName,
+		Protocols: 0b11,
+		HttpPorts: ports,
+	}
+}
+
+// TestDispatcher_ApplyEmitsUpserts confirms a fresh Apply call
+// produces one UPSERT per pod, dispatched to the session whose node
+// matches.
+func TestDispatcher_ApplyEmitsUpserts(t *testing.T) {
+	d := stream.NewDispatcher()
+	s := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(s)
+
+	d.Apply(map[string]*cppb.MonitoringSpec{
+		"pod-1": spec("pod-1", "node-a", 80),
+		"pod-2": spec("pod-2", "node-a", 8080),
+	})
+
+	got := collect(s, 10)
+	if len(got) != 2 {
+		t.Fatalf("got %d msgs; want 2", len(got))
+	}
+	for _, msg := range got {
+		delta := msg.GetSpecDelta()
+		if delta == nil {
+			t.Errorf("msg has no SpecDelta: %v", msg)
+			continue
+		}
+		if delta.GetOp() != cppb.MonitoringSpecDelta_UPSERT {
+			t.Errorf("Op = %v; want UPSERT", delta.GetOp())
+		}
+	}
+}
+
+// TestDispatcher_ApplyIdempotent: re-applying byte-identical specs
+// produces no new deltas (each pod's generation does not bump).
+func TestDispatcher_ApplyIdempotent(t *testing.T) {
+	d := stream.NewDispatcher()
+	s := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(s)
+
+	input := map[string]*cppb.MonitoringSpec{"pod-1": spec("pod-1", "node-a", 80)}
+	d.Apply(input)
+	collect(s, 10) // drain the initial upsert
+
+	d.Apply(input)
+	got := collect(s, 10)
+	if len(got) != 0 {
+		t.Errorf("got %d msgs on idempotent re-apply; want 0", len(got))
+	}
+}
+
+// TestDispatcher_ApplyEmitsRemove: a pod present in lastSpec but
+// absent from the new Apply set produces a REMOVE delta.
+func TestDispatcher_ApplyEmitsRemove(t *testing.T) {
+	d := stream.NewDispatcher()
+	s := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(s)
+
+	d.Apply(map[string]*cppb.MonitoringSpec{
+		"pod-1": spec("pod-1", "node-a", 80),
+		"pod-2": spec("pod-2", "node-a", 8080),
+	})
+	collect(s, 10)
+
+	d.Apply(map[string]*cppb.MonitoringSpec{
+		"pod-1": spec("pod-1", "node-a", 80),
+	})
+
+	got := collect(s, 10)
+	if len(got) != 1 {
+		t.Fatalf("got %d msgs; want 1 REMOVE", len(got))
+	}
+	delta := got[0].GetSpecDelta()
+	if delta == nil || delta.GetOp() != cppb.MonitoringSpecDelta_REMOVE {
+		t.Errorf("expected REMOVE; got %v", delta)
+	}
+	if delta.GetSpec().GetPodUid() != "pod-2" {
+		t.Errorf("REMOVE for wrong pod: %v", delta.GetSpec().GetPodUid())
+	}
+}
+
+// TestDispatcher_RegisterReplaysExistingSpecs: when a session
+// (re)registers, the dispatcher replays the known specs for that
+// node so the agent gets a complete picture without waiting for the
+// next reconcile.
+func TestDispatcher_RegisterReplaysExistingSpecs(t *testing.T) {
+	d := stream.NewDispatcher()
+	// Spec arrives before any session connects (e.g. controller was
+	// up first; agent comes up later).
+	d.Apply(map[string]*cppb.MonitoringSpec{"pod-1": spec("pod-1", "node-a", 80)})
+
+	s := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(s)
+
+	got := collect(s, 10)
+	if len(got) != 1 {
+		t.Fatalf("got %d msgs; want 1 replay UPSERT", len(got))
+	}
+	if got[0].GetSpecDelta().GetOp() != cppb.MonitoringSpecDelta_UPSERT {
+		t.Errorf("expected UPSERT replay; got %v", got[0])
+	}
+}
+
+// TestDispatcher_NodeRoutingFilter: a spec for node-b doesn't land
+// on a session for node-a.
+func TestDispatcher_NodeRoutingFilter(t *testing.T) {
+	d := stream.NewDispatcher()
+	sa := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(sa)
+
+	d.Apply(map[string]*cppb.MonitoringSpec{
+		"pod-1": spec("pod-1", "node-b", 80), // intentionally wrong node
+	})
+
+	got := collect(sa, 10)
+	if len(got) != 0 {
+		t.Errorf("got %d msgs on node-a for a node-b pod; want 0", len(got))
+	}
+}
+
+// TestDispatcher_DisplacedSessionClosed: registering a new session
+// for the same node closes the prior one.
+func TestDispatcher_DisplacedSessionClosed(t *testing.T) {
+	d := stream.NewDispatcher()
+	s1 := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(s1)
+
+	s2 := stream.NewSession("node-a", "v0.4.0")
+	d.RegisterSession(s2)
+
+	// s1's outbound channel should now be closed; reading it should
+	// return immediately with !ok.
+	select {
+	case _, ok := <-s1.Outbound():
+		if ok {
+			t.Error("s1.Outbound() returned a message; expected closed channel")
+		}
+	default:
+		t.Error("s1.Outbound() did not return immediately; expected closed channel")
+	}
+}

--- a/pkg/controller/stream/server.go
+++ b/pkg/controller/stream/server.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"errors"
+	"io"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// Server implements pb.ControlPlaneServer — the controller-side end
+// of the AgentSession bidirectional stream. One Server backs the
+// controller's gRPC listener; per-agent state lives in *Session
+// instances tracked by the shared *Dispatcher.
+type Server struct {
+	cppb.UnimplementedControlPlaneServer
+	Dispatcher *Dispatcher
+
+	// IsLeader is consulted on AgentSession entry. When false, the
+	// stream is rejected with FailedPrecondition so non-leader
+	// replicas don't accept agent traffic. Defaults to "always
+	// leader" if nil (useful for single-replica tests).
+	IsLeader func() bool
+}
+
+// AgentSession is the bidirectional streaming RPC. Lifecycle:
+//
+//  1. Reject if not leader.
+//  2. Receive AgentHello (first message).
+//  3. Construct a *Session, register with Dispatcher (which replays
+//     any known specs for this node).
+//  4. Spawn a goroutine that drains Session.Outbound() onto the
+//     stream's Send().
+//  5. Loop on stream Recv() — handle Heartbeat / Status / Digest;
+//     unknown bodies ignored.
+//  6. On Recv error (client gone / context done): unregister, close
+//     the session, return.
+func (s *Server) AgentSession(stream cppb.ControlPlane_AgentSessionServer) error {
+	if s.IsLeader != nil && !s.IsLeader() {
+		return status.Error(codes.FailedPrecondition, "not leader")
+	}
+	first, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	hello := first.GetHello()
+	if hello == nil {
+		return status.Error(codes.InvalidArgument, "first message must be AgentHello")
+	}
+	if hello.GetNodeName() == "" {
+		return status.Error(codes.InvalidArgument, "AgentHello.node_name is required")
+	}
+	if err := stream.Send(&cppb.ControllerMessage{
+		Body: &cppb.ControllerMessage_Hello{
+			Hello: &cppb.ControllerHello{ControllerVersion: "v0.4.0-dev"},
+		},
+	}); err != nil {
+		return err
+	}
+	sess := NewSession(hello.GetNodeName(), hello.GetAgentVersion())
+	s.Dispatcher.RegisterSession(sess)
+	defer func() {
+		s.Dispatcher.UnregisterSession(sess)
+		sess.close()
+	}()
+
+	// Outbound writer goroutine.
+	sendErr := make(chan error, 1)
+	go func() {
+		for msg := range sess.Outbound() {
+			if err := stream.Send(msg); err != nil {
+				sendErr <- err
+				return
+			}
+		}
+		sendErr <- nil
+	}()
+
+	// Inbound reader loop.
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		// v0.4 ignores AgentHeartbeat / AgentStatus / AgentLocalDigest
+		// payloads — they're plumbed through but not yet consumed by
+		// the reconciler. Phase 3 (#92, #93) wires AgentStatus into
+		// CR status; AgentLocalDigest support lands when reconnect
+		// optimization becomes load-bearing.
+		_ = msg
+		select {
+		case err := <-sendErr:
+			return err
+		default:
+		}
+	}
+}

--- a/pkg/controller/stream/session.go
+++ b/pkg/controller/stream/session.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stream
+
+import (
+	"sync"
+
+	cppb "github.com/gke-labs/in-cluster-observability/pkg/controller/pb/controlplane/v1"
+)
+
+// Session represents one connected agent. Lifecycle is owned by the
+// gRPC stream server (Server.AgentSession): the server constructs
+// the Session on AgentHello, hands it to Dispatcher.RegisterSession,
+// loops on the outbound channel to push messages to the wire, and
+// calls Dispatcher.UnregisterSession + close on stream teardown.
+type Session struct {
+	NodeName     string
+	AgentVersion string
+
+	// out is the per-session outbound queue. Bounded; if it fills
+	// up, deltas are dropped and DropCount increments — the agent
+	// recovers via AgentLocalDigest on reconnect.
+	out chan *cppb.ControllerMessage
+
+	mu        sync.Mutex
+	closed    bool
+	dropCount uint64
+}
+
+// NewSession constructs a Session with a buffered outbound channel.
+// Buffer size is generous — per-pod deltas are tiny, and the worst
+// case (a thousand-pod node churning all at once) is still well
+// under 64 KiB of message data.
+func NewSession(nodeName, agentVersion string) *Session {
+	return &Session{
+		NodeName:     nodeName,
+		AgentVersion: agentVersion,
+		out:          make(chan *cppb.ControllerMessage, 1024),
+	}
+}
+
+// Outbound exposes the per-session channel the gRPC server's send
+// loop reads from. Closed by close().
+func (s *Session) Outbound() <-chan *cppb.ControllerMessage { return s.out }
+
+// DropCount returns the number of messages dropped because the
+// outbound channel was full. Exposed for self-obs.
+func (s *Session) DropCount() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.dropCount
+}
+
+// enqueue is called by the Dispatcher; non-blocking send so a slow
+// or stuck agent never blocks the reconciler.
+func (s *Session) enqueue(msg *cppb.ControllerMessage) {
+	s.mu.Lock()
+	closed := s.closed
+	s.mu.Unlock()
+	if closed {
+		return
+	}
+	select {
+	case s.out <- msg:
+	default:
+		s.mu.Lock()
+		s.dropCount++
+		s.mu.Unlock()
+	}
+}
+
+// close is called by the dispatcher on session displacement or by
+// the server on stream teardown. Idempotent.
+func (s *Session) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	close(s.out)
+}


### PR DESCRIPTION
## Summary

Phase 2 of v0.4 — the controller proper. Closes #87 (reconciler), #88 (gRPC stream), #89 (leader election). Stacked atop Phase 1 (#130) which is stacked atop Phase 0 (#129). PR diff includes those phases' commits until they merge.

This is the milestone's biggest PR by line count. After this lands, the end-to-end loop works: apply a \`TrafficMonitor\` → reconciler computes per-pod \`MonitoringSpec\`s → controller streams them to the agent on the matching node → agent rewrites OBI's \`discovery.instrument\` config → OBI reloads and starts capturing for the matched pods. Phase 3 adds RBAC + CR status reporting.

## What's in this PR

**#87 reconciler — \`pkg/controller/reconciler/\` (one commit):**
- \`spec.go\` — \`ComputeSpec(pod, tms, ctps)\` is the pure 'who covers this pod, what spec results' function. ADR-0003 precedence (namespaced TrafficMonitor wins over ClusterTrafficPolicy); lex-first deterministic tie-break (conflict surfacing in Phase 3).
- \`engine.go\` — Shared 'list everything, compute coverage, dispatch' routine. \`Engine.Recompute(ctx)\` runs on every reconcile event from any of the three watched types. \`Dispatcher\` is a one-method interface here to break the import cycle with \`pkg/controller/stream\`.
- Three controller-runtime Reconcilers (TrafficMonitor / ClusterTrafficPolicy / Pod) all delegate to \`Engine.Recompute\`. v0.4 strategy is full-recompute-on-any-event — simple and correct; targeted incremental reconciliation lands when scale requires it.
- \`spec_test.go\` covers: TM-over-CTP precedence, CTP fallback, no-match, no-enabled-protocol, lex-first tie-break, namespace isolation, protocol bitset encoding.

**#88 gRPC stream — \`pkg/controller/stream/\` + \`pkg/controller/agentclient/\` + \`cmd/ollie/controller_sink.go\` (two commits):**

Controller side:
- \`Dispatcher.Apply(map[podUID]MonitoringSpec)\` diffs against last-known (via \`proto.Equal\`), generates UPSERT for new/changed and REMOVE for absent, bumps monotonic per-pod generation, enqueues onto the right node's session outbound channel.
- \`Session\` — per-agent state. Non-blocking enqueue with \`DropCount\` so a stuck agent never blocks the reconciler.
- \`Server\` implements \`pb.ControlPlaneServer.AgentSession\`. Rejects when not leader (\`FailedPrecondition\`); on \`AgentHello\` registers the session with the dispatcher (which replays known specs); spawns a writer goroutine; loops on \`Recv\`.

Agent side:
- \`agentclient.Client.Run\` dials the controller, runs the bidirectional stream, reconnects with exponential backoff on any error or \`FailedPrecondition\` (controller failover). Heartbeats every 5s. Insecure dial in v0.4 (cert-manager + TLS land with the deferred webhook in v0.5).
- \`captureSink\` (in \`cmd/ollie/\`) bridges UPSERT/REMOVE deltas onto the existing \`capture.Manager.AllowPID\` / \`BlockPID\` interface. v0.4 synthesizes a deterministic 'pseudo-PID' per pod UID in the top half of the uint32 space — the controller doesn't yet supply real PID hints, so this gives us a stable key per pod that flows through the existing OBI discovery writer.
- \`cmd/ollie\` gets \`--controller-addr\` + \`--node-name\` flags. Empty controller-addr → agent stays in standalone v0.3 mode (\`--obi-instrument-ports\` seed still drives discovery).

\`dispatcher_test.go\` covers: UPSERT on new specs, idempotent re-apply, REMOVE for vanished pods, replay on late-registering session, node-routing filter, session displacement closes prior.

**#89 leader election — \`cmd/ollie-controller/main.go\` (one commit):**
- New binary. \`controller-runtime\` manager with \`LeaderElection\` enabled, \`Lease\` named \`ollie-controller\`, \`LeaderElectionReleaseOnCancel\` = true (15s lease, immediate handoff on SIGTERM).
- Three reconcilers registered via \`ctrl.NewControllerManagedBy(...).For(<type>).Named(<name>).Complete(...)\`.
- gRPC stream server on \`--stream-addr\` (default :9102); only accepts \`AgentSession\` when the manager's \`Elected()\` channel has closed.
- Health probes on \`--probe-addr\`, metrics on \`--metrics-addr\`.

## Test plan

- [x] \`go build ./...\` clean (cmd/ollie + cmd/ollie-controller both compile).
- [x] \`go test ./...\` green across all packages.
- [x] \`pkg/controller/reconciler\` and \`pkg/controller/stream\` test coverage exercises the bug-prone paths (precedence, diffing, idempotency, displacement).
- [ ] **Live-cluster end-to-end test deferred to Phase 3** when the RBAC manifest + controller Deployment manifest land. At that point: \`kubectl apply -k k8s/\` + apply nginx + apply TrafficMonitor → see OBI instrument nginx → see HTTP metrics on the agent's :9090 scrape.

## What's NOT in this PR

- RBAC for \`ollie-controller\` ServiceAccount (Phase 3).
- Controller Deployment + Service manifests (Phase 3).
- CR status writes (Phase 3 — \`Ready\`, \`MatchedPodCount\`, \`Conflict\` Condition).
- \`AgentStatus\` consumption (Phase 3).
- Validating admission webhook (deferred to v0.5 per ADR-0022.4).

## Stack-up

```
upstream/main
  ◄── #129  mastersingh24:v0.4/phase-0-design        — design refresh + ADR-0022
  ◄── #130  mastersingh24:v0.4/phase-1-apis          — CRD types + gRPC stubs
  ◄── PR    mastersingh24:v0.4/phase-2-controller    ◄── this PR
  ◄── PR    mastersingh24:v0.4/phase-3-status        — RBAC + CR status + AgentStatus (next)
```